### PR TITLE
Add support for ClojureCollector / EC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Rproj
+*~

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,3 +15,4 @@ Collate:
     's3-costs.r'
     's3-snowplow-event-files-costs.r'
     'snowplow-costs.r'
+    'ec2-costs.r'

--- a/R/database-costs.r
+++ b/R/database-costs.r
@@ -23,13 +23,21 @@ redshiftNodesRequired <- function(eventsStored){
 
 # Amazon Redshift cost
 # Assumes  year reserved instance pricing and XL nodes (not 8XL nodes)
-redshiftEffectiveCostPerMonth <- function(numberOfNodes){
-	upfrontCostPerNode <- 3000
-	hourlyCostPerNode <- 0.114
+redshiftEffectiveCostPerMonth <- function(numberOfNodes, threeyears=FALSE){
 
-	# Cost per month = cost for entire 3 years / 36
-	threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * 3 * numberOfNodes
-	threeYearCost / 36
+  if (threeyears) {
+    upfrontCostPerNode <- 3000
+  	hourlyCostPerNode <- 0.114
+    # Cost per month = cost for entire 3 years / 36
+	  threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * 3 * numberOfNodes
+	  threeYearCost / 36
+  } else {
+    upfrontCostPerNode <- 2500
+  	hourlyCostPerNode <- 0.215
+    # Cost per month = cost for entire 3 years / 36
+	  oneYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * numberOfNodes
+	  oneYearCost / 12
+  }
 }
 
 

--- a/R/database-costs.r
+++ b/R/database-costs.r
@@ -28,7 +28,7 @@ redshiftEffectiveCostPerMonth <- function(numberOfNodes){
 	hourlyCostPerNode <- 0.114
 
 	# Cost per month = cost for entire 3 years / 36
-	threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25 * 3) * numberOfNodes
+	threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * 3 * numberOfNodes
 	threeYearCost / 36
 }
 

--- a/R/ec2-costs.r
+++ b/R/ec2-costs.r
@@ -7,8 +7,8 @@
 ec2CostPerMonth <- function(events){
   eventsProcessableByM3MediumInstance <- 10000000
   nodes <- (events %/% eventsProcessableByM3MediumInstance) + 1
-  hoursInMonth <- 24 * 30
+  hoursPerMonth <- 24*365.25/12
   costOfM3Instance <- 0.098
-	nodes * hoursInMonth * costOfM3Instance
+	nodes * hoursPerMonth * costOfM3Instance
 }
 

--- a/R/ec2-costs.r
+++ b/R/ec2-costs.r
@@ -6,7 +6,7 @@
 # * all requests served to users in the US
 ec2CostPerMonth <- function(events){
   eventsProcessableByM3MediumInstance <- 10000000
-  nodes <- (events %/% eventsProcessableByM3MediumInstance) + 1
+  nodes <- ceiling(events / eventsProcessableByM3MediumInstance)
   hoursPerMonth <- 24*365.25/12
   costOfM3Instance <- 0.098
 	nodes * hoursPerMonth * costOfM3Instance

--- a/R/ec2-costs.r
+++ b/R/ec2-costs.r
@@ -1,0 +1,14 @@
+# Calculate the EC2 cost per month, based on the number of uniques and number of events per month
+
+# Assumptions:
+# * 10M requests can be served by 1 m3.medium instance
+# * using pricing at http://aws.amazon.com/ec2/pricing/
+# * all requests served to users in the US
+ec2CostPerMonth <- function(events){
+  eventsProcessableByM3MediumInstance <- 10000000
+  nodes <- (events %/% eventsProcessableByM3MediumInstance) + 1
+  hoursInMonth <- 24 * 30
+  costOfM3Instance <- 0.098
+	nodes * hoursInMonth * costOfM3Instance
+}
+

--- a/R/s3-costs.r
+++ b/R/s3-costs.r
@@ -39,7 +39,7 @@ s3CostPerMonth <- function(gigabytesSnowplowDataAlreadyInS3, eventsThisMonth, ru
 
 # Calculate the S3 cost per month, based on the volume of data stored, the number of PUT / COPY / POST /  LIST requests and the number of GET requests
 s3CostPerMonthRaw <- function(gigabytesStored, putCopyListRequests, getRequests){
-	storageCostPerGigabyte <- 0.095
+	storageCostPerGigabyte <- 0.03
 	putCopyPostListRequestPricePerThousandRequests <- 0.005
 	getRequestPricePerTenThousandRequests <- 0.004
 

--- a/R/snowplow-costs.r
+++ b/R/snowplow-costs.r
@@ -8,7 +8,7 @@
 #' @param edgeLocations The number of different locations in Amazon's Cloudfront network that each generate an independent log when hit. We believe this number is between 10000 and 100000, but are not sure. (This has an impact on S3 costs)
 #'
 #' @export
-snowplowCostByMonth <- function(uniquesPerMonth, eventsPerMonth, runsPerDay, storageDatabase, numberOfMonths, edgeLocations, collector, managedService = TRUE){
+snowplowCostByMonth <- function(uniquesPerMonth, eventsPerMonth, runsPerDay, storageDatabase, numberOfMonths, edgeLocations, collector="cloudfront", managedService = TRUE){
 	
 	month <- seq(1, numberOfMonths, by=1)
 	

--- a/R/snowplow-costs.r
+++ b/R/snowplow-costs.r
@@ -8,7 +8,7 @@
 #' @param edgeLocations The number of different locations in Amazon's Cloudfront network that each generate an independent log when hit. We believe this number is between 10000 and 100000, but are not sure. (This has an impact on S3 costs)
 #'
 #' @export
-snowplowCostByMonth <- function(uniquesPerMonth, eventsPerMonth, runsPerDay, storageDatabase, numberOfMonths, edgeLocations, collector){
+snowplowCostByMonth <- function(uniquesPerMonth, eventsPerMonth, runsPerDay, storageDatabase, numberOfMonths, edgeLocations, collector, managedService = TRUE){
 	
 	month <- seq(1, numberOfMonths, by=1)
 	
@@ -23,13 +23,18 @@ snowplowCostByMonth <- function(uniquesPerMonth, eventsPerMonth, runsPerDay, sto
   } else {
     ec2Cost <- 0
   }
+  if (managedService) {
+    managed <- 1000
+  } else {
+    managed <- 0
+  }
 	s3Cost <- s3CostByMonth(eventsPerMonth, runsPerDay, edgeLocations, numberOfMonths)
 	emrCost <- emrCostPerMonth(eventsPerMonth, runsPerDay)
 	databaseCost <- databaseCostByMonth(storageDatabase, eventsPerMonth, numberOfMonths)
 
 	# Combine above 4 costs in a single data frame:
-	snowplowCost <- data.frame(month, cloudfrontCost, s3Cost, emrCost, databaseCost, ec2Cost)
-	snowplowCost$totalCost <- snowplowCost$cloudfrontCost + snowplowCost$s3Cost + snowplowCost$emrCost + snowplowCost$databaseCost + ec2Cost
+	snowplowCost <- data.frame(month, cloudfrontCost, s3Cost, emrCost, databaseCost, ec2Cost, managed)
+	snowplowCost$totalCost <- snowplowCost$cloudfrontCost + snowplowCost$s3Cost + snowplowCost$emrCost + snowplowCost$databaseCost + ec2Cost + managed
 
 	# Now return the completed data frame
 	snowplowCost

--- a/R/snowplow-costs.r
+++ b/R/snowplow-costs.r
@@ -19,7 +19,7 @@ snowplowCostByMonth <- function(uniquesPerMonth, eventsPerMonth, runsPerDay, sto
     cloudfrontCost <- 0
   }
   if (collector=="clojure") {
-    ec2Cost <- ec2CostPerMonth(events)
+    ec2Cost <- ec2CostPerMonth(eventsPerMonth)
   } else {
     ec2Cost <- 0
   }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The `snowplowCostByMonth` function takes the following arguments, all of which *
 | `storageDatabase` | `string`  | The database that is used to store Snowplow data. This can be 'redshift' or 'postgres' |
 | `numberOfMonths`  | `integer` | The number of months that the model will run for |
 | `edgeLocations`   | `integer` | This is the number of locations on the Amazon Cloudfront network that generate a log file each time one of the associated nodes is hit. We are not sure how many of these exist in the Cloudfront network. (We guess there are 10k - 100k). This impacts S3 costs, because it determines how many log files are generated in each time period, and a certain number of requests are made per log file generated. |
+| `collector`       | `string`  | The type of collector used to receive Snowplow data. This can be 'cloudfront' or 'clojure' |
+| `managedService`  | `boolean` | Whether to include managed service costs in the calculation |
 
 For example, to find out how much Snowplow would cost for a user with 800k uniques per month, 5M events per month who uses PostgreSQL to store the data, we would run:
 


### PR DESCRIPTION
Here is a PR for **discussion**. 

I added support for modelling ClojureCollector/EC2. 

I had to make some assumptions about the type of instance / how many events it could handle. I assumed a M3Medium instance could process 10 million events. Of course it's maximal throughput which is the real problem - like Glastonbury or Apple live events.

However it is still not quite right, the S3 cost still use the number of edge locations, but for the Clojure collector there are no edge locations, right?

Also I updated the S3 storage cost as mentioned in #1. 
