### PR TITLE
#4 candidate fix for Redshift pricing model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Rproj
+*~

--- a/R/database-costs.r
+++ b/R/database-costs.r
@@ -23,13 +23,21 @@ redshiftNodesRequired <- function(eventsStored){
 
 # Amazon Redshift cost
 # Assumes  year reserved instance pricing and XL nodes (not 8XL nodes)
-redshiftEffectiveCostPerMonth <- function(numberOfNodes){
-	upfrontCostPerNode <- 3000
-	hourlyCostPerNode <- 0.114
+redshiftEffectiveCostPerMonth <- function(numberOfNodes, threeyears=FALSE){
 
-	# Cost per month = cost for entire 3 years / 36
-	threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * 3 * numberOfNodes
-	threeYearCost / 36
+  if (threeyears) {
+    upfrontCostPerNode <- 3000
+  	hourlyCostPerNode <- 0.114
+    # Cost per month = cost for entire 3 years / 36
+	  threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * 3 * numberOfNodes
+	  threeYearCost / 36
+  } else {
+    upfrontCostPerNode <- 2500
+  	hourlyCostPerNode <- 0.215
+    # Cost per month = cost for entire 3 years / 36
+	  oneYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * numberOfNodes
+	  oneYearCost / 12
+  }
 }
 
 

--- a/R/database-costs.r
+++ b/R/database-costs.r
@@ -28,7 +28,7 @@ redshiftEffectiveCostPerMonth <- function(numberOfNodes){
 	hourlyCostPerNode <- 0.114
 
 	# Cost per month = cost for entire 3 years / 36
-	threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25 * 3) * numberOfNodes
+	threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25) * 3 * numberOfNodes
 	threeYearCost / 36
 }
 


### PR DESCRIPTION
I was comparing the output of the model with my calculator and I couldn't understand why my calculator was predicting an average Redshift cost of around $330 - $365 a month and the cost model was predicting $167:

```
    # Cost per month = cost for entire 3 years / 36
    threeYearCost <- (upfrontCostPerNode + hourlyCostPerNode * 24 * 365.25 * 3) * numberOfNodes
    threeYearCost / 36
```

The problem is the up front cost is per year, not over 3 years.
